### PR TITLE
jdbc join push down

### DIFF
--- a/RFC-0009-jdbc-join-push-down.md
+++ b/RFC-0009-jdbc-join-push-down.md
@@ -1,0 +1,57 @@
+# **RFC0 for Presto**
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on creating your RFC and the process surrounding it.
+
+## [Title]
+
+Proposers
+
+*
+*
+
+## [Related Issues]
+
+Related issues may include Github issues, PRs or other RFCs.
+
+## Summary
+
+Briefly describe what you intend to propose
+
+## Background
+
+Brief description of any existing issues, user requests or feature comparison with competitors which explains why the proposed feature might be needed. How the proposed feature helps our users? Explain the impact and value of this feature.
+
+### [Optional] Goals
+
+### [Optional] Non-goals
+
+## Proposed Implementation
+
+How do you intend to implement the feature? This section can be as detailed as possible with large subsections of its own, or may be a few sentences depending on the scope of the feature proposed. Explain the design in enough detail for existing users/contributors to understand. Design should include all the corner cases you can think of. Feel free to include any new SPI method signatures, class hierarchies or system contracts here. It is recommended to mention any methods, variables, classes, or SQL language additions which you think are needed to provide a broader view of the code changes. Please mention/describe the below on a high level -
+
+1. What modules are involved
+2. Any new terminologies/concepts/SQL language additions
+3. Method/class/interface contracts which you deem fit for implementation.
+4. Code flow using bullet points or pseudo code as applicable
+5. Any new user facing metrics that can be shown on CLI or UI.
+
+## [Optional] Metrics
+
+How can we measure the impact of this feature?
+
+## [Optional] Other Approaches Considered
+
+Based on the discussion, this may need to be updated with feedback from reviewers.
+
+## Adoption Plan
+
+- What impact (if any) will there be on existing users? Are there any new session parameters, configurations, SPI updates, client API updates, or SQL grammar?
+- If we are changing behaviour how will we phase out the older behaviour?
+- If we need special migration tools, describe them here.
+- When will we remove the existing behaviour, if applicable.
+- How should this feature be taught to new and existing users? Basically mention if documentation changes/new blog are needed?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+## Test Plan
+
+How do we ensure the feature works as expected? Mention if any functional tests/integration tests are needed. Special mention for product-test changes. If any PoC has been done already, please mention the relevant test results here that you think will bolster your case of getting this RFC approved.

--- a/RFC-0009-jdbc-join-push-down.md
+++ b/RFC-0009-jdbc-join-push-down.md
@@ -1,39 +1,158 @@
-# **RFC0 for Presto**
+# **RFC0009-jdbc-join-push-down for Presto**
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on creating your RFC and the process surrounding it.
 
-## [Title]
+## Jdbc join pushdown in presto
 
 Proposers
 
-*
-*
+* Ajas M M
 
-## [Related Issues]
 
-Related issues may include Github issues, PRs or other RFCs.
+## Related Issues
+
+https://github.com/prestodb/presto/issues/23152
 
 ## Summary
 
-Briefly describe what you intend to propose
+At present, when a query joins multiple tables, it creates a separate TableScanNode for each table. Each TableScanNode select all the records from that table. The join operation is then executed in-memory in Presto using a JOIN node by applying JoinCriteria, FilterPredicate and other criteria (like sort, limit, etc.).
+
+However, if the query joins tables from the same JDBC datasource, it would be more efficient to let the datasource handle the join instead of creating a separate TableScanNode for each table and joining them in Presto. If we "Push down" or send these joins to remote JDBC datasource it increases the performance 3x to 10x.
+
+For example, for the below postgres join query if we push down the join to a single TableScanNode, then the Presto Plan and performance will be as follows.
+
+**Join Query**
+
+```
+SELECT order_id,
+       c_customer_id
+FROM postgresql.public.orders o
+    INNER JOIN postgresql.public.customer c ON c.c_customer_id = o.customer_id;
+```
+
+
+
+**Original presto plan**
+
+```
+
+ - Output[PlanNodeId 9][order_id, c_customer_id] => [order_id:integer, c_customer_id:char(16)]
+    - RemoteStreamingExchange[PlanNodeId 266][GATHER] => [order_id:integer, c_customer_id:char(16)]
+        - InnerJoin[PlanNodeId 4][("customer_id" = "c_customer_id")][$hashvalue, $hashvalue_11] => [order_id:integer, c_customer_id:char(16)]
+                Distribution: PARTITIONED
+            - RemoteStreamingExchange[PlanNodeId 264][REPARTITION][$hashvalue] => [customer_id:char(16), order_id:integer, $hashvalue:bigint]
+                    Estimates: {source: CostBasedSourceInfo, rows: ? (?), cpu: ?, memory: 0.00, network: ?}
+                - ScanProject[PlanNodeId 0,326][table = TableHandle {connectorId='postgresql', connectorHandle='postgresql:public.orders:null:public:orders', layout='Optional[{domains=ALL, additionalPredicate={}}]'}, projectLocality = LOCAL] => [customer_id:char(16), order_id:integer, $hashvalue_10:bigint]
+                        Estimates: {source: CostBasedSourceInfo, rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
+                        $hashvalue_10 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(customer_id), BIGINT'0')) (1:45)
+                        LAYOUT: {domains=ALL, additionalPredicate={}}
+                        order_id := JdbcColumnHandle{connectorId=postgresql, columnName=order_id, jdbcTypeHandle=JdbcTypeHandle{jdbcType=4, jdbcTypeName=int4, columnSize=10, decimalDigits=0, arrayDimensions=null}, columnType=integer, nullable=true, comment=Optional.empty} (1:45)
+                        customer_id := JdbcColumnHandle{connectorId=postgresql, columnName=customer_id, jdbcTypeHandle=JdbcTypeHandle{jdbcType=1, jdbcTypeName=bpchar, columnSize=16, decimalDigits=0, arrayDimensions=null}, columnType=char(16), nullable=true, comment=Optional.empty} (1:45)
+            - LocalExchange[PlanNodeId 297][HASH][$hashvalue_11] (c_customer_id) => [c_customer_id:char(16), $hashvalue_11:bigint]
+                    Estimates: {source: CostBasedSourceInfo, rows: ? (?), cpu: ?, memory: 0.00, network: ?}
+                - RemoteStreamingExchange[PlanNodeId 265][REPARTITION][$hashvalue_12] => [c_customer_id:char(16), $hashvalue_12:bigint]
+                        Estimates: {source: CostBasedSourceInfo, rows: ? (?), cpu: ?, memory: 0.00, network: ?}
+                    - ScanProject[PlanNodeId 1,327][table = TableHandle {connectorId='postgresql', connectorHandle='postgresql:public.customer:null:public:customer', layout='Optional[{domains=ALL, additionalPredicate={}}]'}, projectLocality = LOCAL] => [c_customer_id:char(16), $hashvalue_13:bigint]
+                            Estimates: {source: CostBasedSourceInfo, rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
+                            $hashvalue_13 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(c_customer_id), BIGINT'0')) (2:12)
+                            LAYOUT: {domains=ALL, additionalPredicate={}}
+                            c_customer_id := JdbcColumnHandle{connectorId=postgresql, columnName=c_customer_id, jdbcTypeHandle=JdbcTypeHandle{jdbcType=1, jdbcTypeName=bpchar, columnSize=16, decimalDigits=0, arrayDimensions=null}, columnType=char(16), nullable=true, comment=Optional.empty} (2:12)
+
+```
+
+**Joinpushdown presto plan**
+
+```
+ - Output[PlanNodeId 9][order_id, c_customer_id] => [order_id:integer, c_customer_id:char(16)]
+        Estimates: {source: CostBasedSourceInfo, rows: ? (?), cpu: ?, memory: 0.00, network: ?}
+    - RemoteStreamingExchange[PlanNodeId 233][GATHER] => [order_id:integer, c_customer_id:char(16)]
+            Estimates: {source: CostBasedSourceInfo, rows: ? (?), cpu: ?, memory: 0.00, network: ?}
+        - TableScan[PlanNodeId 217][TableHandle {connectorId='postgresql', connectorHandle='postgresql:public.orders:null:public:orders', layout='Optional[{domains=ALL, additionalPredicate={}}]'}] => [order_id:integer, c_customer_id:char(16)]
+                Estimates: {source: CostBasedSourceInfo, rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
+                LAYOUT: {domains=ALL, additionalPredicate={}}
+                order_id := JdbcColumnHandle{connectorId=postgresql, columnName=order_id, jdbcTypeHandle=JdbcTypeHandle{jdbcType=4, jdbcTypeName=int4, columnSize=10, decimalDigits=0, arrayDimensions=null}, columnType=integer, nullable=true, comment=Optional.empty} (1:45)
+                c_customer_id := JdbcColumnHandle{connectorId=postgresql, columnName=c_customer_id, jdbcTypeHandle=JdbcTypeHandle{jdbcType=1, jdbcTypeName=bpchar, columnSize=16, decimalDigits=0, arrayDimensions=null}, columnType=char(16), nullable=true, comment=Optional.empty} (2:12)
+``` 
+
+**Original presto plan performance**
+
+![Original presto plan performance](RFC-0004-single_jdbc_join_pushdown/1_perf_wxd.png)
+
+
+**Joinpushdown presto plan performance**
+
+![Joinpushdown presto plan performance](RFC-0004-single_jdbc_join_pushdown/2_perf_joinwxd.png)  
+
 
 ## Background
 
-Brief description of any existing issues, user requests or feature comparison with competitors which explains why the proposed feature might be needed. How the proposed feature helps our users? Explain the impact and value of this feature.
+This implementation is to address a performance limitation of Presto federation of SQLs of JDBC connector to remote data sources such as DB2, Postgres, Oracle etc. Currently, Presto support predicate pushdown (WHERE condition pushdown) to some extent in JDBC connectors, but it does not have any join pushdown capabilities. This cause high performance impact on join queries and it is raised by some of our client. While comparing with competitors we also missing the Jdbc join pushdown capabilities.
 
-### [Optional] Goals
+We did a POC by changing the presto generated PlanNode to handle jdbc join push down and it increases the performance from 5x on postgres and  8x on db2 remote datasource. Now we need to perform its actual implementation 
 
-### [Optional] Non-goals
 
 ## Proposed Implementation
 
-How do you intend to implement the feature? This section can be as detailed as possible with large subsections of its own, or may be a few sentences depending on the scope of the feature proposed. Explain the design in enough detail for existing users/contributors to understand. Design should include all the corner cases you can think of. Feel free to include any new SPI method signatures, class hierarchies or system contracts here. It is recommended to mention any methods, variables, classes, or SQL language additions which you think are needed to provide a broader view of the code changes. Please mention/describe the below on a high level -
+At present, if presto get a join query (from the CLI or UI) which is trying to join tables either from same datasource or from different datasource, it is receiving as a string formatted sql query. Presto validate the syntax and convert it to Query (Statement) object using presto parser and analyzer. This Query object is converted to presto internal reference architecture called Plan, using its logical and physical optimizers. Finally, this plan is executed by the executor.
 
-1. What modules are involved
-2. Any new terminologies/concepts/SQL language additions
-3. Method/class/interface contracts which you deem fit for implementation.
-4. Code flow using bullet points or pseudo code as applicable
-5. Any new user facing metrics that can be shown on CLI or UI.
+![Joinpushdown presto plan performance](RFC-0004-single_jdbc_join_pushdown/basic_wrk.png)  
+
+Currently for the join query, presto create a final plan which contains separate TableScanNode for each table that participated on join query and this TableScanNode info is used by the connector to create the select query. On top of this select query result, presto apply join condition and other predicate to provide the final result.
+
+![Joinpushdown presto plan performance](RFC-0004-single_jdbc_join_pushdown/cur_join_wrks.png) 
+
+In the proposed implementation, all tables from the join query are trying to group based on the Jdbc connector (data source) name. And create a single TableScanNode for each jdbc connector by using the grouped table info, whenever it is possible. It ensures a single TableScanNode against a connector rather than each table of a join query. 
+
+**For example consider below join query**
+
+``` 
+select t  *
+
+from postgresql.pg.mypg_table1 t1
+
+join postgresql.pg.mypg_table2 t2 on t1.pgfirsttablecolumn=t2.pgsecondtablecolumn
+
+Join db2.db2.mydb2_table1 t3 on t3.DBTHRIDTABLECOLUMN=t2.pgsecondtablecolumn
+
+JOIN db2.db2.mydb2_table2 t4 ON t3.DBTHRIDTABLECOLUMN=t4.dbfourthtablecolumn
+
+JOIN db2.db2.mydb2_table3 t5 ON t4.dbfourthtablecolumn=t5.dbfifthtablecolumn
+``` 
+
+**Here we have five tables,** 
+
+mypg_table1 and  mypg_table12 from postgresql connector (data source)
+
+mydb2_table1, mydb2_table2 and mydb2_table3 from db2 connector
+
+
+At present, presto create five select statement (TableScanNode) for this query as follows
+
+| No | Node Description                   | SQL Query                                                         |
+|----|-------------------------------------|-------------------------------------------------------------------|
+| 1  | TableScanNode for mypg_table1       | `select t * from postgresql.pg.mypg_table1 t1`                    |
+| 2  | TableScanNode for mypg_table2       | `select t * from postgresql.pg.mypg_table2 t2`                    |
+| 3  | TableScanNode for mypg_table1       | `select t * from db2.db2.mydb2_table1 t3`                         |
+| 4  | TableScanNode for mypg_table1       | `select t * from db2.db2.mydb2_table2 t4`                         |
+| 5  | TableScanNode for mypg_table1       | `select t * from db2.db2.mydb2_table3 t5`                         |
+
+
+
+In our proposed implementation, we restrict select statement (TableScanNode) creation based on tables and trying to create select statement (TableScanNode) against each connector by grouping the tables based on the connector
+
+| No | Node Description                                  | SQL Query                                                                                                  |
+|----|---------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| 1  | TableScanNode [mypg_table1, mypg_table2] for PostgreSQL | `select t * from postgresql.pg.mypg_table1 t1, postgresql.pg.mypg_table2 t2 where t1.pgfirsttablecolumn=t2.pgsecondtablecolumn` |
+| 2  | TableScanNode [mypg_table1, mypg_table2, mypg_table3] for DB2 | `select t * from db2.db2.mydb2_table1 t3, db2.db2.mydb2_table2 t4, db2.db2.mydb2_table5 t5 where t3.DBTHRIDTABLECOLUMN=t4.dbfourthtablecolumn and t4.dbfourthtablecolumn=t5.dbfifthtablecolumn` |
+
+
+
+For performing this jdbc join pushdown,  we need to create a new logical optimiser called JdbcJoinRenderByConnector  GroupInnerJoinsByConnector
+
+optimiser which is responsible for grouping Jdbc connector specific tables into a single TableScanNode based on JdbcJoinPushdown condition. Along with the single TableScanNode, the grouped table info and its join criteria need to pass to the Jdbc to create the final join query. The final join query is prepared at the connector level using the Querybulder.
+
+
+
 
 ## [Optional] Metrics
 

--- a/RFC-0009-jdbc-join-push-down.md
+++ b/RFC-0009-jdbc-join-push-down.md
@@ -7,6 +7,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on creating your RFC and
 Proposers
 
 * Ajas M M
+* Haritha K
+* Thanzeel Hassan
+* Glerin Pinhero
 
 
 ## Related Issues


### PR DESCRIPTION
IBM presto can push down the processing of  join queries, or part of  join queries into the connected jdbc data source. 

The results of this pushdown can include the following benefits:

- Improved overall query performance

- Reduced network traffic between IBM presto and the data source

- Reduced load on the remote data source 

- Significant cost reduction due to limited number of database hit