### PR TITLE
Rename RFC file for custom schemas support

### DIFF
--- a/RFC-0017-Support-custom-schemas-in-native-sidecar-function-registry.md
+++ b/RFC-0017-Support-custom-schemas-in-native-sidecar-function-registry.md
@@ -1,4 +1,4 @@
-# **RFC-0021 for Presto**
+# **RFC-0017 for Presto**
 
 ## [Title] Support custom schemas in native sidecar function registry
 


### PR DESCRIPTION
RFC-0017 is actually unused, keep it at 17